### PR TITLE
Add initial project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,6 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
 # Distribution / packaging
 .Python
+env/
 build/
 develop-eggs/
 dist/
@@ -19,86 +12,12 @@ lib64/
 parts/
 sdist/
 var/
-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
+# Serverless directories
+.serverless
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
+# Node.js
+node_modules/

--- a/handler.py
+++ b/handler.py
@@ -1,0 +1,2 @@
+def authorize(event, context):
+    pass

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "jwt-custom-authorizer",
+  "version": "1.0.0",
+  "description": "An AWS Custom Authorizer for AWS API Gateway that supports JSON Web Tokens (JWT)",
+  "author": "Diogo Nicoleti <diogo.nicoleti@gmail.com>",
+  "scripts": {
+    "deploy": "./node_modules/.bin/serverless deploy"
+  },
+  "devDependencies": {
+    "serverless": "^1.33.2",
+    "serverless-offline": "^3.31.3",
+    "serverless-python-requirements": "^4.2.5"
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,14 @@
+service: jwt-custom-authorizer
+
+plugins:
+  - serverless-python-requirements
+  - serverless-offline
+
+provider:
+  name: aws
+  runtime: python3.6
+  region: us-east-1
+
+functions:
+  jwt-custom-authorizer:
+    handler: handler.authorize


### PR DESCRIPTION
Add initial project files for the AWS Custom Authorizer for AWS API Gateway that supports JSON Web Tokens (JWT).

For this project, we can't use Chalice because the lambda function will not be exposed as a API endpoint, because this I used Serverless instead. 

The language remains Python to standardize with the other lambda functions